### PR TITLE
add effect on 'add bp' button interactions

### DIFF
--- a/front/app/containers/NavBar/style.scss
+++ b/front/app/containers/NavBar/style.scss
@@ -20,7 +20,10 @@ div.section.vde-navbar {
 }
 
 .vde.dropdown.nav-item:hover,
-.vde.dropdown.nav-item:focus {
+.vde.dropdown.nav-item:focus,
+.home-add-bp.level-item:hover,
+.home-add-bp.level-item:focus
+{
   border-color: $dark;
   border-width: thin;
   border-style: outset;
@@ -68,6 +71,7 @@ div.level.vde-navbar {
   align-items: center;
   justify-content: center;
   font-size: x-large;
+  cursor: pointer;
 }
 
 .level.is-mobile .home-add-bp.level-item:not(:last-child) {
@@ -95,5 +99,3 @@ span.home-add-bp a .icon {
   justify-content: center;
   transition: filter 300ms;
 }
-
-


### PR DESCRIPTION
Add effect to the + button on the top right corner, when hovering over it. 

![image](https://user-images.githubusercontent.com/6451881/89333637-8b137200-d695-11ea-8bf7-b5e39750c7b6.png)

It was bothering me to have the effect on the other 2 buttons but not this one. Disregard if there is a reason behind it.

Only tested through live edit without launching the app in dev, sorry.